### PR TITLE
Changelog clarifies workspace limits

### DIFF
--- a/get-started/changelog.mdx
+++ b/get-started/changelog.mdx
@@ -19,7 +19,6 @@ title: "Changelog"
   [**Workspaces**](https://docs.bezi.com/fundamentals/workspaces):
 
   - One hub to contain all relevant Unity projects, local folders, pages, threads, and rules for the work
-  - No limits on the number of individual and Team Workspaces you can have/be added to
 
   [**Connections**](https://docs.bezi.com/context/connections): _Unity projects & local folders_
 


### PR DESCRIPTION
## Summary
This update to the changelog clarifies information about workspace limits, removing an outdated statement about unlimited individual and Team Workspaces.

## Changes
- Removed a bullet point stating there are no limits on the number of individual and Team Workspaces.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/bezi/bezi/editor/workspace-update?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->