### PR TITLE
Fix changelog plugin download link

### DIFF
--- a/get-started/changelog.mdx
+++ b/get-started/changelog.mdx
@@ -8,7 +8,7 @@ title: "Changelog"
   **Plugin**: v0.85.2
 </Info>
 
-<Card title="Download Plugin v0.85.2" icon="sparkles" href="https://github.com/bezi3d/bezi-unity-plugin-releases/releases/download/v0.85.2/com.bezi.sidekick-0.85.2tgz">
+<Card title="Download Plugin v0.85.2" icon="sparkles" href="https://github.com/bezi3d/bezi-unity-plugin-releases/releases/download/v0.85.2/com.bezi.sidekick-0.85.2.tgz">
 </Card>
 
 <Update label="04/29/2026">


### PR DESCRIPTION
## Summary
This change corrects the download link for the v0.85.2 plugin in the changelog.

## Changes
- Updated the plugin download URL in `get-started/changelog.mdx` to include the correct file extension.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/bezi/bezi/editor/url-update?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->